### PR TITLE
Add Academic Prospectus Page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,8 @@ function App() {
         <Route path="/anti-ragging" element={<AntiRagging />} />
         <Route path="/anti-ragging-committee" element={<AntiRaggingCommittee />} />
         <Route path="/about/academic-heads" element={<Academicheads />} /> 
-           <Route path="/students-section/courses" element={<Courses />} />
+        <Route path="/students-section/courses" element={<Courses />} />
+        <Route path="/prospectus" element={<AcademicProspectusPage />} />
         {/* Add more routes here */}
       </Routes>
       <Footer />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import AntiRagging from "./pages/Students-Section/Student-Welfare/Anti-Ragging/A
 import AntiRaggingCommittee from './pages/Students-Section/Student-Welfare/Anti-Ragging-Committee/AntiRaggingCommittee';
 import Academicheads from './pages/AcadmicHeads/Academicheads.jsx';
 import Courses from './pages/Courses/Courses.jsx';
+import AcademicProspectusPage from './pages/Academic-Prospectus/AcademicProspectusPage.jsx';
 function App() {
   return (
     <HashRouter>

--- a/src/components/header/AcademicsMenu.jsx
+++ b/src/components/header/AcademicsMenu.jsx
@@ -39,7 +39,7 @@ const AcademicsMenu = () => {
             links: [
                 { name: 'Courses Offered', path: '/students-section/courses' },   // ✅ Now clickable
                 'Academic Calendar', 
-                'Academic Prospectus', 
+                { name: 'Academic Prospectus', path: '/prospectus' },  
                 'Affiliating University'
             ],
         },

--- a/src/pages/Academic-Prospectus/AcademicProspectusPage.css
+++ b/src/pages/Academic-Prospectus/AcademicProspectusPage.css
@@ -1,0 +1,74 @@
+.academic-prospectus-container {
+  padding: 2rem;
+  background-color: #ffffff;
+  color: #1f2937; 
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.academic-prospectus-container h1 {
+  font-size: 2.5rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+
+.academic-prospectus-container p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin-bottom: 2rem;
+}
+
+.prospectus-viewer {
+  width: 100%;
+  height: 600px;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.download-button {
+  margin-top: 1rem;
+  display: inline-block;
+  background-color: #2563eb; 
+  color: white;
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.375rem;
+  text-decoration: none;
+  transition: background-color 0.3s ease;
+}
+
+.download-button:hover {
+  background-color: #1d4ed8; 
+}
+
+.previous-prospectus-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.prospectus-item {
+  padding: 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 0.3s ease;
+}
+
+.prospectus-item:hover {
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
+}
+
+.prospectus-item a {
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.prospectus-item a:hover {
+  text-decoration: underline;
+}

--- a/src/pages/Academic-Prospectus/AcademicProspectusPage.jsx
+++ b/src/pages/Academic-Prospectus/AcademicProspectusPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import './AcademicProspectusPage.css';
+
+const AcademicProspectusPage = () => {
+  return (
+    <div className="academic-prospectus-container">
+      {/* Content will go here */}
+    </div>
+  );
+};
+
+export default AcademicProspectusPage;

--- a/src/pages/Academic-Prospectus/AcademicProspectusPage.jsx
+++ b/src/pages/Academic-Prospectus/AcademicProspectusPage.jsx
@@ -22,7 +22,22 @@ The CCET prospectus presents a comprehensive overview of our institution, highli
       </p>
 
       {/* Current Year Prospectus */}
-
+      <h2>Prospectus 2025-26</h2>
+      <div className="prospectus-viewer">
+        <iframe
+          src={currentProspectusURL}
+          title="Prospectus 2025-26"
+          width="100%"
+          height="100%"
+        ></iframe>
+      </div>
+      <a
+        href={currentProspectusURL}
+        download
+        className="download-button"
+      >
+        Download PDF
+      </a>
 
       {/* Previous Years Prospectus */}
 

--- a/src/pages/Academic-Prospectus/AcademicProspectusPage.jsx
+++ b/src/pages/Academic-Prospectus/AcademicProspectusPage.jsx
@@ -2,9 +2,30 @@ import React from 'react';
 import './AcademicProspectusPage.css';
 
 const AcademicProspectusPage = () => {
+  const currentProspectusURL = "/ccet-website/public/pdfs/Prospectus-2025.pdf";
+
+  const previousProspectuses = [
+    { year: "2024-25", url: "/ccet-website/public/pdfs/Prospectus-2024.pdf" },
+    { year: "2023-24", url: "/ccet-website/public/pdfs/Prospectus-2023.pdf" },
+    { year: "2022-23", url: "/ccet-website/public/pdfs/Prospectus-2022.pdf" },
+    { year: "2021-22", url: "/ccet-website/public/pdfs/Prospectus-2022.pdf" },
+    { year: "2020-21", url: "/ccet-website/public/pdfs/Prospectus-2022.pdf" },
+  ];
+
   return (
     <div className="academic-prospectus-container">
-      {/* Content will go here */}
+      {/* Description Section */}
+      <h1>Academic Prospectus</h1>
+      <p>
+        Prospectus Overview – CCET
+The CCET prospectus presents a comprehensive overview of our institution, highlighting our accredited programs in engineering and technology, highly qualified faculty, state-of-the-art infrastructure, and student-centered learning environment. It serves as a resource for prospective students, parents, and stakeholders to understand our academic vision, admission procedures, and commitment to excellence in technical education.
+      </p>
+
+      {/* Current Year Prospectus */}
+
+
+      {/* Previous Years Prospectus */}
+
     </div>
   );
 };

--- a/src/pages/Academic-Prospectus/AcademicProspectusPage.jsx
+++ b/src/pages/Academic-Prospectus/AcademicProspectusPage.jsx
@@ -40,7 +40,15 @@ The CCET prospectus presents a comprehensive overview of our institution, highli
       </a>
 
       {/* Previous Years Prospectus */}
-
+      <h2 style={{ marginTop: "2rem" }}>Previous Year Prospectuses</h2>
+      <div className="previous-prospectus-list">
+        {previousProspectuses.map(({ year, url }) => (
+          <div key={year} className="prospectus-item">
+            <span>Prospectus {year}</span>
+            <a href={url} download>Download</a>
+          </div>
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
### 📘 Summary
This PR introduces the **Academic Prospectus** page to the CCET website. The page displays the current year's prospectus in an embedded PDF viewer and lists downloadable links for previous academic years.

---

### 🧩 Key Features
- 📄 **AcademicProspectusPage.jsx**: New React component for the Prospectus section
- 🎨 **AcademicProspectusPage.css**: Dedicated styles for layout and responsiveness
- 📥 Embedded **PDF viewer** for the 2025-26 prospectus
- 📚 List of **previous year prospectuses** with direct download links
- 🧭 Added route to `App.jsx` → `/prospectus`
- 🔗 Added navigation link under **Academics → Overview** in `AcademicsMenu.jsx`

---

### 📁 Files Modified
- `src/pages/Academic-Prospectus/AcademicProspectusPage.jsx`
- `src/pages/Academic-Prospectus/AcademicProspectusPage.css`
- `src/App.jsx`
- `src/components/header/AcademicsMenu.jsx`
- `public/pdfs/*.pdf`

---