### PR TITLE
Remove Online Fee Payment Link from Old Notices

### DIFF
--- a/src/components/header/NoticesMenu.jsx
+++ b/src/components/header/NoticesMenu.jsx
@@ -8,10 +8,6 @@ const NoticesMenu = () => {
       links: [
         { name: "Forms", url: "/forms" },
         { name: "Tenders", url: "/notices/tenders" },
-        {
-          name: "Online Fee Payment Link",
-          url: "https://paydirect.eduqfix.com/app/3qTjKfysWsfqEyNTM4giVFX4VGVYGZss5NYRHpY65DaJgmu14S3Ff6NKoVa3l2Ay/6593",
-        },
       ],
     },
     {


### PR DESCRIPTION
<img width="1696" height="434" alt="image" src="https://github.com/user-attachments/assets/1840ac33-149b-4b39-ba09-7b35e6aba03d" />
closes #201 