### PR TITLE
fix: rename Nopage folder to NoPage for consistency

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import "./App.css";
 import "./index.css";
 
-import NoPage from "./pages/Nopage/NoPage.jsx";
+import NoPage from "./pages/NoPage/NoPage.jsx";
 import FAQ from "./pages/FAQ/faq";
 import Nss from "./pages/Nss/Nss.jsx";
 import VisionMission from "./pages/vision-mission/vision-mission.jsx";


### PR DESCRIPTION
This PR renames the `Nopage` folder to `NoPage` to maintain consistent naming conventions 
throughout the project. All imports and references in `App.jsx` have been updated accordingly.

- Updated import in App.jsx: `import NoPage from "./pages/NoPage/NoPage.jsx";`
- Updated the wildcard route to use `<NoPage />`

No other functionality has been changed. This is purely a structural/cleanup change.
